### PR TITLE
upgrade ansible core for deps

### DIFF
--- a/.github/workflows/build-execution-environment.yml
+++ b/.github/workflows/build-execution-environment.yml
@@ -165,55 +165,42 @@ jobs:
             fi
           done
 
+      - name: Setup Docker config for attestation
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/playbook-nest') || (github.event_name == 'workflow_dispatch' && inputs.push_to_registry)
+        run: |
+          # Create docker config directory
+          mkdir -p ~/.docker
+          
+          # Copy podman auth to docker config location for attestation action
+          # Podman auth is stored in ~/.config/containers/auth.json or ${XDG_RUNTIME_DIR}/containers/auth.json
+          if [ -f "${XDG_RUNTIME_DIR}/containers/auth.json" ]; then
+            cp "${XDG_RUNTIME_DIR}/containers/auth.json" ~/.docker/config.json
+            echo "Copied podman auth from XDG_RUNTIME_DIR"
+          elif [ -f ~/.config/containers/auth.json ]; then
+            cp ~/.config/containers/auth.json ~/.docker/config.json
+            echo "Copied podman auth from ~/.config/containers/auth.json"
+          elif [ -f /run/containers/$(id -u)/auth.json ]; then
+            cp /run/containers/$(id -u)/auth.json ~/.docker/config.json
+            echo "Copied podman auth from /run/containers"
+          else
+            echo "Warning: Could not find podman auth file, checking /run/user"
+            if [ -f "/run/user/$(id -u)/containers/auth.json" ]; then
+              cp "/run/user/$(id -u)/containers/auth.json" ~/.docker/config.json
+              echo "Copied podman auth from /run/user"
+            else
+              echo "Error: No podman auth file found"
+              exit 1
+            fi
+          fi
+          
+          # Verify the config was copied
+          echo "Docker config location:"
+          ls -la ~/.docker/config.json
+        
       - name: Generate artifact attestation
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/playbook-nest') || (github.event_name == 'workflow_dispatch' && inputs.push_to_registry)
-        env:
-          DOCKER_CONFIG: /tmp/.docker
-        run: |
-          # Create docker config directory and copy podman credentials
-          mkdir -p /tmp/.docker
-          
-          # Extract podman credentials and create docker config
-          USERNAME="${{ github.actor }}"
-          TOKEN="${{ secrets.GITHUB_TOKEN }}"
-          REGISTRY_AUTH=$(printf "%s:%s" "$USERNAME" "$TOKEN" | base64 -w 0)
-          # Provide credentials under multiple keys some tooling expects
-          cat > /tmp/.docker/config.json << EOF
-          {
-            "auths": {
-              "ghcr.io": {
-                "auth": "$REGISTRY_AUTH",
-                "username": "$USERNAME",
-                "password": "$TOKEN"
-              },
-              "https://ghcr.io": {
-                "auth": "$REGISTRY_AUTH",
-                "username": "$USERNAME",
-                "password": "$TOKEN"
-              },
-              "https://ghcr.io/v1/": {
-                "auth": "$REGISTRY_AUTH",
-                "username": "$USERNAME",
-                "password": "$TOKEN"
-              }
-            },
-            "HttpHeaders": {
-              "User-Agent": "github-actions-attest"
-            }
-          }
-          EOF
-          
-          # Use the attestation action with custom docker config
-          echo "Using podman-compatible credentials for attestation"
-        
-      - name: Generate artifact attestation with podman credentials
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/playbook-nest') || (github.event_name == 'workflow_dispatch' && inputs.push_to_registry)
         uses: actions/attest-build-provenance@v1
-        env:
-          DOCKER_CONFIG: /tmp/.docker
         with:
-          # Use repo from docker/metadata-action and strip tag using supported functions
-          # subject-name must NOT include a tag when a digest is provided
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build-execution-environment.yml
+++ b/.github/workflows/build-execution-environment.yml
@@ -7,6 +7,7 @@ on:
       - playbook-nest
     paths:
       - 'execution-environment.yml'
+      - 'ansible.cfg'
       - 'requirements.yml'
       - 'requirements.txt'
       - 'bindep.txt'
@@ -16,6 +17,7 @@ on:
       - main
     paths:
       - 'execution-environment.yml'
+      - 'ansible.cfg'
       - 'requirements.yml'
       - 'requirements.txt'
       - 'bindep.txt'
@@ -72,6 +74,9 @@ jobs:
           # Show what we're building with
           echo "=== Execution Environment Configuration ==="
           cat execution-environment.yml
+          echo
+          echo "=== Ansible Configuration ==="
+          cat ansible.cfg
           echo
           echo "=== Collection Requirements ==="
           cat requirements.yml

--- a/.github/workflows/build-execution-environment.yml
+++ b/.github/workflows/build-execution-environment.yml
@@ -153,7 +153,8 @@ jobs:
           
           # Test that ansible.netcommon collection is available
           echo "=== Testing ansible.netcommon collection ==="
-          podman run --rm temp-ee:latest ansible-doc ansible.netcommon.network_cli || echo "ansible.netcommon.network_cli documentation not found, but collection may still be functional"
+          echo "Listing available connection plugins from ansible.netcommon:"
+          podman run --rm temp-ee:latest ansible-doc -t connection -l | grep netcommon || echo "Warning: No netcommon connection plugins listed"
 
       - name: Push to registry
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/playbook-nest') || (github.event_name == 'workflow_dispatch' && inputs.push_to_registry)

--- a/EXECUTION_ENVIRONMENT.md
+++ b/EXECUTION_ENVIRONMENT.md
@@ -32,7 +32,7 @@ ghcr.io/<owner>/<repo>/ansible-ee:latest
 
 ### Ansible Collections
 - `cisco.asa` (>=5.0.0)
-- `ansible.netcommon` (>=5.3.0, <6.0.0) - Compatible with ansible-core 2.15.x
+- `ansible.netcommon` (5.3.0) - Pinned version compatible with ansible-core 2.15.x
 
 ### Python Dependencies
 - `pyyaml` (>=6.0)

--- a/EXECUTION_ENVIRONMENT.md
+++ b/EXECUTION_ENVIRONMENT.md
@@ -24,15 +24,15 @@ ghcr.io/<owner>/<repo>/ansible-ee:latest
 ## Included Components
 
 ### Base Image
-- `registry.access.redhat.com/ubi9/ubi:9.6` - Red Hat Universal Base Image 9
+- `registry.access.redhat.com/ubi9/python-311:latest` - Red Hat UBI 9 with Python 3.11
 
 ### Ansible Core & Runner
-- `ansible-core` (>=2.15.0)
+- `ansible-core` (>=2.17.0) - Required for latest ansible.netcommon
 - `ansible-runner` (>=2.3.0) - Required for execution environment functionality
 
 ### Ansible Collections
-- `cisco.asa` (>=5.0.0)
-- `ansible.netcommon` (5.3.0) - Pinned version compatible with ansible-core 2.15.x
+- `cisco.asa` (>=6.0.0)
+- `ansible.netcommon` (>=8.0.0) - Compatible with ansible-core 2.17.x+
 
 ### Python Dependencies
 - `pyyaml` (>=6.0)
@@ -118,10 +118,11 @@ The execution environment is automatically built and pushed to GHCR when:
 
 1. Changes are pushed to the `main` or `playbook-nest` branch that affect:
    - `execution-environment.yml`
+   - `ansible.cfg`
    - `requirements.yml`
    - `requirements.txt`
    - `bindep.txt`
-   - `_build/**`
+   - `.github/workflows/build-execution-environment.yml`
 
 2. The workflow is manually triggered via `workflow_dispatch`
 
@@ -140,7 +141,8 @@ The execution environment build includes:
 
 The execution environment is defined by these files:
 
-- `execution-environment.yml` - Main EE definition with embedded ansible.cfg
+- `execution-environment.yml` - Main EE definition
+- `ansible.cfg` - Ansible configuration
 - `requirements.yml` - Ansible collection dependencies
 - `requirements.txt` - Python package dependencies
 - `bindep.txt` - System package dependencies

--- a/EXECUTION_ENVIRONMENT.md
+++ b/EXECUTION_ENVIRONMENT.md
@@ -27,7 +27,7 @@ ghcr.io/<owner>/<repo>/ansible-ee:latest
 - `registry.access.redhat.com/ubi9/ubi:9.6` - Red Hat Universal Base Image 9
 
 ### Ansible Core & Runner
-- `ansible-core` (>=2.15.0) - Installed via pip
+- `ansible-core` (>=2.16.0)
 - `ansible-runner` (>=2.3.0) - Required for execution environment functionality
 
 ### Ansible Collections

--- a/EXECUTION_ENVIRONMENT.md
+++ b/EXECUTION_ENVIRONMENT.md
@@ -27,12 +27,12 @@ ghcr.io/<owner>/<repo>/ansible-ee:latest
 - `registry.access.redhat.com/ubi9/ubi:9.6` - Red Hat Universal Base Image 9
 
 ### Ansible Core & Runner
-- `ansible-core` (>=2.16.0)
+- `ansible-core` (>=2.15.0)
 - `ansible-runner` (>=2.3.0) - Required for execution environment functionality
 
 ### Ansible Collections
 - `cisco.asa` (>=5.0.0)
-- `ansible.netcommon` (>=6.0.0)
+- `ansible.netcommon` (>=5.3.0, <6.0.0) - Compatible with ansible-core 2.15.x
 
 ### Python Dependencies
 - `pyyaml` (>=6.0)

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,11 @@
+[defaults]
+stdout_callback = yaml
+timeout = 30
+gathering = explicit
+collections_path = /usr/share/ansible/collections
+
+[inventory]
+enable_plugins = host_list, script, auto, yaml, ini, toml
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null

--- a/ansible/ansible_collections/cisa/ed_25_03/README.md
+++ b/ansible/ansible_collections/cisa/ed_25_03/README.md
@@ -7,7 +7,7 @@ Reference: [CISA ED 25-03: Core Dump & Hunt Instructions](https://www.cisa.gov/n
 Important: Follow CISA's guidance exactly and in order. Deviations may trigger anti-forensics and destroy evidence. This automation aims to issue exact CLI commands without tab completion or autocomplete.
 
 Prerequisites
-- Ansible 2.15+
+- Ansible 2.17+
 - Collections: `cisco.asa`, `ansible.netcommon`
 - Connectivity to Cisco ASA via SSH using `network_cli`
 

--- a/ansible/ansible_collections/cisa/ed_25_03/galaxy.yml
+++ b/ansible/ansible_collections/cisa/ed_25_03/galaxy.yml
@@ -19,5 +19,5 @@ tags:
   - incident_response
   - forensics
 dependencies:
-  ansible.netcommon: ">=6.0.0"
-  cisco.asa: ">=5.0.0"
+  ansible.netcommon: ">=8.0.0"
+  cisco.asa: ">=6.0.0"

--- a/ansible/ansible_collections/cisa/ed_25_03/meta/runtime.yml
+++ b/ansible/ansible_collections/cisa/ed_25_03/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.17.0"

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/collect_artifacts/README.md
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/collect_artifacts/README.md
@@ -116,7 +116,7 @@ artifacts/
 
 ## Prerequisites
 
-- Ansible 2.15+
+- Ansible 2.17+
 - Collections: `cisco.asa`, `ansible.netcommon`
 - SSH connectivity to Cisco ASA devices
 - Sufficient disk space on control node for output files

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/collect_artifacts/meta/main.yml
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/collect_artifacts/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Kush Gupta
   description: Collect ASA artifacts per ED 25-03
   license: Apache-2.0
-  min_ansible_version: 2.15.0
+  min_ansible_version: 2.17.0
 dependencies: []
 collections:
   - cisco.asa

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/core_dump/README.md
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/core_dump/README.md
@@ -143,7 +143,7 @@ artifacts/
 
 ## Prerequisites
 
-- Ansible 2.15+
+- Ansible 2.17+
 - Collections: `cisco.asa`, `ansible.netcommon`
 - **Maintenance Window**: Coordinate with stakeholders
 - **Manual Power Cycle Capability**: Physical access or remote power management

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/core_dump/meta/main.yml
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/core_dump/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Kush Gupta
   description: Perform core dump preparation and trigger on ASA (DANGEROUS)
   license: Apache-2.0
-  min_ansible_version: 2.15.0
+  min_ansible_version: 2.17.0
 dependencies: []
 collections:
   - cisco.asa

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/hunt_syslog_checks/README.md
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/hunt_syslog_checks/README.md
@@ -204,7 +204,7 @@ artifacts/
 
 ## Prerequisites
 
-- Ansible 2.15+
+- Ansible 2.17+
 - ASA syslog files available on the control node
 - Sufficient disk space for analysis output
 - Python 3.6+ for JSON processing

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/hunt_syslog_checks/meta/main.yml
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/hunt_syslog_checks/meta/main.yml
@@ -3,6 +3,6 @@ galaxy_info:
   author: Kush Gupta
   description: Analyze ASA syslog files for ED 25-03 indicators
   license: Apache-2.0
-  min_ansible_version: 2.15.0
+  min_ansible_version: 2.17.0
 dependencies: []
 collections: []

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/patch_checks/README.md
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/patch_checks/README.md
@@ -250,7 +250,7 @@ artifacts/
 
 ## Prerequisites
 
-- Ansible 2.15+
+- Ansible 2.17+
 - Collections: `cisco.asa`, `ansible.netcommon`
 - SSH connectivity to Cisco ASA devices
 - Sufficient privileges to read filesystem contents

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/patch_checks/meta/main.yml
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/patch_checks/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Kush Gupta
   description: Check for firmware update logs and patching evidence
   license: Apache-2.0
-  min_ansible_version: 2.15.0
+  min_ansible_version: 2.17.0
 dependencies: []
 collections:
   - cisco.asa

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/report/meta/main.yml
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/report/meta/main.yml
@@ -3,6 +3,6 @@ galaxy_info:
   author: Kush Gupta
   description: Generate consolidated ED 25-03 assessment reports
   license: Apache-2.0
-  min_ansible_version: 2.15.0
+  min_ansible_version: 2.17.0
 dependencies: []
 collections: []

--- a/ansible/ansible_collections/cisa/ed_25_03/roles/version_assessment/meta/main.yml
+++ b/ansible/ansible_collections/cisa/ed_25_03/roles/version_assessment/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Kush Gupta
   description: Assess ASA version and known vulnerability context
   license: Apache-2.0
-  min_ansible_version: 2.15.0
+  min_ansible_version: 2.17.0
 dependencies: []
 collections:
   - cisco.asa

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: cisco.asa
-    version: ">=5.0.0"
-  - name: ansible.netcommon
     version: ">=6.0.0"
+  - name: ansible.netcommon
+    version: ">=8.0.0"
 

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: registry.access.redhat.com/ubi10/python-312:latest
+    name: registry.access.redhat.com/ubi10/python-312-minimal:latest
 
 dependencies:
   # Install ansible-core first, before galaxy collections

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -8,7 +8,7 @@ images:
 dependencies:
   # Install ansible-core first, before galaxy collections
   ansible_core:
-    package_pip: ansible-core>=2.16.0
+    package_pip: ansible-core>=2.15.0
   # Install ansible-runner (required for execution environments)
   ansible_runner:
     package_pip: ansible-runner>=2.3.0

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -21,8 +21,10 @@ dependencies:
 
 additional_build_steps:
   prepend_base:
-    # Install essential packages (Python 3.11 already included in base image)
-    - RUN dnf update -y && dnf install -y git openssh-clients && dnf clean all
+    # Install Python 3.11 and essential packages
+    - RUN dnf update -y && dnf install -y python3.11 python3.11-pip git openssh-clients && dnf clean all
+    # Set Python 3.11 as the default python3
+    - RUN alternatives --set python3 /usr/bin/python3.11 || update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
   prepend_galaxy:
     # Verify ansible-core and ansible-runner installation before galaxy operations
     - RUN ansible --version

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -8,7 +8,7 @@ images:
 dependencies:
   # Install ansible-core first, before galaxy collections
   ansible_core:
-    package_pip: ansible-core>=2.15.0
+    package_pip: ansible-core>=2.16.0
   # Install ansible-runner (required for execution environments)
   ansible_runner:
     package_pip: ansible-runner>=2.3.0

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: registry.access.redhat.com/ubi10/python-312-minimal:latest
+    name: quay.io/centos/centos:stream9
 
 dependencies:
   # Install ansible-core first, before galaxy collections

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,12 +3,12 @@ version: 3
 
 images:
   base_image:
-    name: registry.access.redhat.com/ubi9/ubi:9.6
+    name: registry.access.redhat.com/ubi9/python-311:latest
 
 dependencies:
   # Install ansible-core first, before galaxy collections
   ansible_core:
-    package_pip: ansible-core>=2.15.0
+    package_pip: ansible-core>=2.17.0
   # Install ansible-runner (required for execution environments)
   ansible_runner:
     package_pip: ansible-runner>=2.3.0
@@ -21,27 +21,15 @@ dependencies:
 
 additional_build_steps:
   prepend_base:
-    # Install essential packages and Python
-    - RUN dnf update -y && dnf install -y python3 python3-pip git openssh-clients && dnf clean all
+    # Install essential packages (Python 3.11 already included in base image)
+    - RUN dnf update -y && dnf install -y git openssh-clients && dnf clean all
   prepend_galaxy:
     # Verify ansible-core and ansible-runner installation before galaxy operations
     - RUN ansible --version
     - RUN ansible-galaxy --version
     - RUN ansible-runner --version
   append_final:
-    # Create ansible configuration directory
-    - RUN mkdir -p /etc/ansible
-    # Create ansible configuration file
-    - RUN echo '[defaults]' > /etc/ansible/ansible.cfg
-    - RUN echo 'stdout_callback = yaml' >> /etc/ansible/ansible.cfg
-    - RUN echo 'timeout = 30' >> /etc/ansible/ansible.cfg
-    - RUN echo 'gathering = explicit' >> /etc/ansible/ansible.cfg
-    - RUN echo 'collections_path = /usr/share/ansible/collections' >> /etc/ansible/ansible.cfg
-    - RUN echo '' >> /etc/ansible/ansible.cfg
-    - RUN echo '[inventory]' >> /etc/ansible/ansible.cfg
-    - RUN echo 'enable_plugins = host_list, script, auto, yaml, ini, toml' >> /etc/ansible/ansible.cfg
-    - RUN echo '' >> /etc/ansible/ansible.cfg
-    - RUN echo '[ssh_connection]' >> /etc/ansible/ansible.cfg
-    - RUN echo 'ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null' >> /etc/ansible/ansible.cfg
+    # Copy ansible configuration
+    - COPY ansible.cfg /etc/ansible/ansible.cfg
     # Verify ansible configuration
     - RUN cat /etc/ansible/ansible.cfg

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -5,6 +5,10 @@ images:
   base_image:
     name: quay.io/centos/centos:stream9
 
+additional_build_files:
+  - src: ansible.cfg
+    dest: configs/
+
 dependencies:
   # Install ansible-core first, before galaxy collections
   ansible_core:
@@ -32,6 +36,6 @@ additional_build_steps:
     - RUN ansible-runner --version
   append_final:
     # Copy ansible configuration
-    - COPY ansible.cfg /etc/ansible/ansible.cfg
+    - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
     # Verify ansible configuration
     - RUN cat /etc/ansible/ansible.cfg

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: quay.io/centos/centos:stream9
+    name: registry.redhat.io/ubi9/python-311:latest
 
 additional_build_files:
   - src: ansible.cfg

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: registry.access.redhat.com/ubi9/python-312:latest
+    name: registry.access.redhat.com/ubi10/python-312:latest
 
 dependencies:
   # Install ansible-core first, before galaxy collections

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: registry.access.redhat.com/ubi9/python-311:latest
+    name: registry.access.redhat.com/ubi9/python-312:latest
 
 dependencies:
   # Install ansible-core first, before galaxy collections

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: registry.redhat.io/ubi9/python-311:latest
+    name: registry.access.redhat.com/ubi9/python-311:latest
 
 additional_build_files:
   - src: ansible.cfg

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 collections:
   - name: cisco.asa
-    version: ">=5.0.0"
+    version: ">=6.0.0"
   - name: ansible.netcommon
-    version: "5.3.0"
+    version: ">=8.0.0"

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: cisco.asa
     version: ">=5.0.0"
   - name: ansible.netcommon
-    version: ">=5.3.0,<6.0.0"
+    version: "5.3.0"

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: cisco.asa
     version: ">=5.0.0"
   - name: ansible.netcommon
-    version: ">=6.0.0"
+    version: ">=5.3.0,<6.0.0"


### PR DESCRIPTION
## Summary by Sourcery

Upgrade ansible-core dependency to 2.16.0 and streamline the GitHub Actions attestation workflow by reusing existing Podman auth files instead of generating a custom Docker config

Enhancements:
- Bump ansible-core requirement to >=2.16.0 in execution-environment config and documentation
- Simplify attestation workflow: rename setup step, copy Podman auth to ~/.docker/config.json, and remove manual config generation and DOCKER_CONFIG env variable

CI:
- Update build-execution-environment GitHub Actions workflow with new step names and auth handling for attestation